### PR TITLE
Added support for message to `orElseThrow` method

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+- [ ] This pull request does not contain any breaking change.
+- [ ] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
+<!-- ⇅ remove it if it doesn't make sense ⇅ -->
+<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
+>> Could you briefly summarize the following code for me?
+>> ```python
+>> class Tiger:
+>>    def __init__(self, name):
+>>       self.name = name
+>>
+>>    def roar(self):
+>>       print(f"{self.name} lets out a powerful roar!")
+>> ```
+>
+> This code defines a Python class named `Tiger` with a constructor that initializes the tiger's name, and a `roar` method that prints a message including the tiger's name. Simple and elegant, just like a tiger! 🐅
+>
+>> Could you show me how to use it?
+>
+> Sure, here's how to create and use a `Tiger` object with the class you have:
+> ```python
+> # Create an instance of Tiger
+> my_tiger = Tiger("Gopal")
+> 
+> # Call the roar method
+> my_tiger.roar()
+> ```
+>
+> When you run this code, it will output:
+> ```
+> Gopal lets out a powerful roar!
+> ```
+>
+> That's how you bring your Tiger to life! 🎉
+>
+>> Is there any way to do it better?
+>
+> Absolutely. You could add error handling, additional methods, or even inheritance. Here's an enhanced version:
+> ```python
+> class Tiger:
+>     def __init__(self, name):
+>         self.name = name
+> 
+>     def roar(self):
+>         print(f"{self.name} lets out a powerful roar!")
+> 
+>     def introduce(self):
+>         print(f"Meet {self.name}, the majestic tiger!")
+>
+> # Usage
+> my_tiger = Tiger("Gopal")
+> my_tiger.introduce()  # Output: Meet Gopal, the majestic tiger!
+> my_tiger.roar()  # Output: Gopal lets out a powerful roar!
+> ```
+>
+> Now your tiger can introduce itself, too. 🐯📢
+<!-- ↑ this is an example, replace it ↑ -->

--- a/.molireali
+++ b/.molireali
@@ -3,6 +3,7 @@ composer PetrKnap\\Optional
 dockerfile php 8.1-cli
 docker-scripts petrknap/php-optional
 donation
+github-templates
 github-workflow docker "composer ci-script"
 github-workflow linter-docker
 github-workflow linter-php 8.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,10 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       git \
       unzip \
- && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
- && php -r "copy('https://composer.github.io/installer.sig', 'composer-setup.php.sig');" \
- && php -r "if (trim(hash_file('SHA384', 'composer-setup.php')) === trim(file_get_contents('composer-setup.php.sig'))) { echo 'Installer verified' . PHP_EOL; exit(0); } else { echo 'Installer corrupt' . PHP_EOL; unlink('composer-setup.php'); unlink('composer-setup.php.sig'); exit(-1); }" \
- && php composer-setup.php \
- && php -r "unlink('composer-setup.php'); unlink('composer-setup.php.sig');" \
- && mv composer.phar /usr/local/bin/composer \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
 ;
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 # endregion
 
 # region included composer-library

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,4 @@
 {
-  "WARNING": "This file is updated automatically. All keys will be overwritten, except of 'conflict', 'keywords', 'require', 'require-dev', 'scripts' and 'suggest'.",
   "autoload": {
     "psr-4": {
       "PetrKnap\\Optional\\": "src"
@@ -33,27 +32,28 @@
   "require-dev": {
     "nunomaduro/phpinsights": "^2.11",
     "petrknap/shorts": "^2.1",
-    "phpstan/phpstan": "^1.10",
+    "phpstan/phpstan": "^1.12",
     "phpunit/phpunit": "^10.5",
     "squizlabs/php_codesniffer": "^3.7"
   },
   "scripts": {
     "test": "phpunit --colors=always --testdox tests",
     "check-requirements": [
+      "composer update \"petrknap/*\"",
       "composer outdated \"petrknap/*\" --major-only --strict --ansi --no-interaction"
     ],
     "check-implementation": [
       "phpcs --colors --standard=PSR12 --exclude=Generic.Files.LineLength src tests",
       "phpstan analyse --level max src --ansi --no-interaction",
       "phpstan analyse --level 5 tests --ansi --no-interaction",
-      "phpinsights analyse src --ansi --no-interaction"
+      "phpinsights analyse src tests --ansi --no-interaction --format=github-action | sed -e \"s#::error file=$PWD/#::notice file=#g\""
     ],
     "test-implementation": [
       "@test"
     ],
     "ci-script": [
-      "@check-requirements",
       "@check-implementation",
+      "@check-requirements",
       "@test-implementation"
     ]
   }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "require-dev": {
     "nunomaduro/phpinsights": "^2.11",
-    "petrknap/shorts": "^2.1",
+    "petrknap/shorts": "^3.0",
     "phpstan/phpstan": "^1.12",
     "phpunit/phpunit": "^10.5",
     "squizlabs/php_codesniffer": "^3.7"

--- a/src/Optional.php
+++ b/src/Optional.php
@@ -164,12 +164,12 @@ abstract class Optional implements JavaSe8\Optional
      */
     public function orElseThrow(
         null|string|callable $exceptionSupplier = null,
-        string|null $exceptionMessage = null,
+        string|null $message = null,
     ): mixed {
         if ($exceptionSupplier === null) {
-            return $this->orElseThrow(static fn () => match ($exceptionMessage) {
+            return $this->orElseThrow(static fn () => match ($message) {
                 null => new Exception\CouldNotGetValueOfEmptyOptional(),
-                default => new Exception\CouldNotGetValueOfEmptyOptional($exceptionMessage),
+                default => new Exception\CouldNotGetValueOfEmptyOptional($message),
             });
         }
 
@@ -178,15 +178,15 @@ abstract class Optional implements JavaSe8\Optional
             if (!class_exists($exceptionSupplier, autoload: true)) {
                 throw new InvalidArgumentException('Exception supplier must be existing class name.');
             }
-            return $this->orElseThrow(static fn () => match ($exceptionMessage) {
+            return $this->orElseThrow(static fn () => match ($message) {
                 null => new $exceptionSupplier(),
-                default => new $exceptionSupplier($exceptionMessage),
+                default => new $exceptionSupplier($message),
             });
         }
 
-        return $this->orElseGet(static function () use ($exceptionSupplier, $exceptionMessage): never {
+        return $this->orElseGet(static function () use ($exceptionSupplier, $message): never {
             /** @var Throwable|mixed $exception */
-            $exception = $exceptionSupplier($exceptionMessage);
+            $exception = $exceptionSupplier($message);
             if ($exception instanceof Throwable) {
                 throw $exception;
             }

--- a/src/Optional.php
+++ b/src/Optional.php
@@ -156,16 +156,21 @@ abstract class Optional implements JavaSe8\Optional
     /**
      * @template E of Throwable
      *
-     * @param null|class-string<E>|callable(): E $exceptionSupplier
+     * @param null|class-string<E>|callable(string|null $message): E $exceptionSupplier
      *
      * @return T
      *
      * @throws E
      */
-    public function orElseThrow(null|string|callable $exceptionSupplier = null): mixed
-    {
+    public function orElseThrow(
+        null|string|callable $exceptionSupplier = null,
+        string|null $exceptionMessage = null,
+    ): mixed {
         if ($exceptionSupplier === null) {
-            return $this->orElseThrow(static fn () => new Exception\CouldNotGetValueOfEmptyOptional());
+            return $this->orElseThrow(static fn () => match ($exceptionMessage) {
+                null => new Exception\CouldNotGetValueOfEmptyOptional(),
+                default => new Exception\CouldNotGetValueOfEmptyOptional($exceptionMessage),
+            });
         }
 
         if (is_string($exceptionSupplier)) {
@@ -173,12 +178,15 @@ abstract class Optional implements JavaSe8\Optional
             if (!class_exists($exceptionSupplier, autoload: true)) {
                 throw new InvalidArgumentException('Exception supplier must be existing class name.');
             }
-            return $this->orElseThrow(static fn () => new $exceptionSupplier());
+            return $this->orElseThrow(static fn () => match ($exceptionMessage) {
+                null => new $exceptionSupplier(),
+                default => new $exceptionSupplier($exceptionMessage),
+            });
         }
 
-        return $this->orElseGet(static function () use ($exceptionSupplier): never {
+        return $this->orElseGet(static function () use ($exceptionSupplier, $exceptionMessage): never {
             /** @var Throwable|mixed $exception */
-            $exception = $exceptionSupplier();
+            $exception = $exceptionSupplier($exceptionMessage);
             if ($exception instanceof Throwable) {
                 throw $exception;
             }


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the meaning of `$message` argument in following code for me?
>> ```php
>> class Optional implements JavaSe8\Optional
>> {
>>     # ...
>> 
>>     /**
>>      * @template E of Throwable
>>      *
>>      * @param null|class-string<E>|callable(string|null $message): E $exceptionSupplier
>>      *
>>      * @return T
>>      *
>>      * @throws E
>>      */
>>     public function orElseThrow(
>>         null|string|callable $exceptionSupplier = null,
>>         string|null $message = null,
>>     ): mixed {/*...*/}
>> }
>> ```
>
> Of course! In this code, the `$message` argument in the `orElseThrow` method serves as an optional error message to be used when an exception is thrown.
>
> Here's a breakdown of its role:
> - **Type**: The `$message` argument is of type `string|null`, meaning it can either be a string (containing the error message) or `null` (indicating no specific error message).
> - **Usage**: When the `orElseThrow` method is called, if the `exceptionSupplier` is provided and an exception needs to be thrown, the `$message` can be used as the error message for the exception.
> - **Optional**: The `$message` argument is optional, as indicated by the `= null` default value. If no specific message is provided, a default behavior or message can be used.
>
> So, the `$message` argument essentially allows you to customize the error message when throwing an exception using the `orElseThrow` method.
>
>> Could you show me how to use it?
>
> Sure! Here's an example of how you might use the `orElseThrow` method in the `Optional` class with the `$message` argument to customize the error message for the thrown exception:
> ```php
> try {
>     // Assume $optional is an instance of Optional that is empty (value is null)
>     $optional = new Optional();
>     
>     // Using a class-string exception supplier with a custom message
>     $value = $optional->orElseThrow(\InvalidArgumentException::class, 'Custom error message');
>     
> } catch (\InvalidArgumentException $e) {
>     echo 'Caught exception: ', $e->getMessage(); // Outputs: Caught exception: Custom error message
> }
> 
> try {
>     // Using a callable exception supplier with a custom message
>     $value = $optional->orElseThrow(function ($message) {
>         return new \Exception($message);
>     }, 'Another custom error message');
>     
> } catch (\Exception $e) {
>     echo 'Caught exception: ', $e->getMessage(); // Outputs: Caught exception: Another custom error message
> }
> ```
>
>> Is there any way to name `$message` better?
> 
> Definitely! Naming variables for clarity and purpose is essential for maintainability. For the `$message` argument, you might consider names that reflect its role as an error or exception message. Here are a few suggestions:
> - **$errorMessage**
> - **$exceptionMessage**
> - **$customMessage**
>
> Each of these names clearly indicates that the variable is related to the message used when throwing an exception.