### PR TITLE
Added `toNullable` method

### DIFF
--- a/src/Optional.php
+++ b/src/Optional.php
@@ -195,6 +195,16 @@ abstract class Optional implements JavaSe8\Optional
     }
 
     /**
+     * Inverse of {@see self::ofNullable()}
+     *
+     * @return T|null
+     */
+    public function toNullable(): mixed
+    {
+        return $this->value;
+    }
+
+    /**
      * @param mixed $value not null
      */
     abstract protected static function isSupported(mixed $value): bool;

--- a/tests/OptionalTest.php
+++ b/tests/OptionalTest.php
@@ -33,16 +33,18 @@ final class OptionalTest extends TestCase
         Optional::of(null);
     }
 
-    public function testMethodOfFalsableWorks(): void
+    #[DataProvider('dataMethodOfFalsableWorks')]
+    public function testMethodOfFalsableWorks(Optional $expectedOptional, mixed $value): void
     {
-        self::assertEquals(
-            Optional::ofNullable(null),
-            Optional::ofFalsable(false),
-        );
-        self::assertEquals(
-            Optional::ofNullable(self::VALUE),
-            Optional::ofFalsable(self::VALUE),
-        );
+        self::assertEquals($expectedOptional, Optional::ofFalsable($value));
+    }
+
+    public static function dataMethodOfFalsableWorks(): array
+    {
+        return self::makeDataSet([
+            [self::VALUE],
+            [false],
+        ]);
     }
 
     #[DataProvider('dataMethodOfNullableWorks')]
@@ -257,6 +259,20 @@ final class OptionalTest extends TestCase
             $data[2] = $data[5] = $data[4] === null ? null : $message;
             yield "{$name} + supplier(class name) + message" => $data;
         }
+    }
+
+    #[DataProvider('dataMethodToNullableWorks')]
+    public function testMethodToNullableWorks(Optional $optional, mixed $expectedValue): void
+    {
+        self::assertSame($expectedValue, $optional->toNullable());
+    }
+
+    public static function dataMethodToNullableWorks(): array
+    {
+        return self::makeDataSet([
+            [self::VALUE],
+            [null],
+        ]);
     }
 
     private static function makeDataSet(array $args): array


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the method `asNullable` from the following code for me?
>> ```php
>> /**
>>  * @extends Optional<int>
>>  */
>> class SomeOptional extends Optional {
>>     /**
>>      * @return int|null
>>      */
>>     public function asNullable(): mixed
>>     {
>>         return $this->value;
>>     }
>> }
>> ```
>
> Absolutely! The `asNullable` method in your `SomeOptional` class returns the value of the instance, which can be either an integer or null. Essentially, it's a way to convert the optional value to a nullable type. It makes accessing the value more flexible, as it allows for handling cases where the value might not be present.
>
> I hope this clears things up! How's your coding project going?
>
>> Could you show me how to use it?
>
> Sure thing! Here's an example of how you might use the `asNullable` method in your `SomeOptional` class. Let's say you have an instance of `SomeOptional` that holds a value:
> ```php
> // Create an instance of SomeOptional with a value.
> $optional = new SomeOptional(42);
> 
> // Use the asNullable method to get the value or null.
> $value = $optional->asNullable();
> 
> if ($value !== null) {
>     echo "The value is: " . $value;
> } else {
>     echo "The value is null.";
> }
> ```
>
> In this example, we create an instance of `SomeOptional` with a value of `42`. Then, we call the `asNullable` method to retrieve the value. The code checks if the value is null and outputs either the value or a message indicating that the value is null.
>
> I hope this helps! Let me know if you have any more questions or need further assistance with your project.
>
>> Is there any way to name the method better?
>
> Certainly! Choosing a more descriptive name for the method can improve code readability and make its purpose clearer to other developers. Here are a few alternative names for the `asNullable` method:
> 1. `getValueOrNull`
> 2. `toNullable`
> 3. `optionalValue`
> 4. `nullableValue`
> 5. `getNullable`
>
> Each of these names emphasizes that the method retrieves a nullable value from the optional object.
>
> Do you have a preference for one of these names, or is there a specific context that might suggest a different name? I'm happy to help you brainstorm further!
>
>> Which matches better to method `ofNullable`?
> 
> Given the method `ofNullable`, it makes sense to maintain consistency in your method naming convention. In that case, `toNullable` matches better with `ofNullable`. The consistent use of "to" and "of" can make the code more readable and intuitive:
> - `ofNullable`: Indicates that the method takes a nullable value.
> - `toNullable`: Indicates that the method converts to a nullable value.
>
> Using similar patterns helps keep the codebase clean and easier to understand.
>
> Does that work for you? If you need any more assistance, feel free to ask!