### PR TITLE
Semi-correct `equals` behavior

### DIFF
--- a/src/OptionalObject.php
+++ b/src/OptionalObject.php
@@ -26,6 +26,10 @@ abstract class OptionalObject extends Optional
             }
             /** @var static */
             return new class ($value) extends OptionalObject {
+                protected static function isInstanceOfStatic(object $obj): bool
+                {
+                    return $obj instanceof OptionalObject;
+                }
                 protected static function getInstanceOf(): string
                 {
                     TypedOptional::triggerNotice(OptionalObject::class . ' does not check the instance of object.');

--- a/src/OptionalResource.php
+++ b/src/OptionalResource.php
@@ -24,6 +24,10 @@ abstract class OptionalResource extends Optional
             }
             /** @var static */
             return new class ($value) extends OptionalResource {
+                protected static function isInstanceOfStatic(object $obj): bool
+                {
+                    return $obj instanceof OptionalResource;
+                }
                 protected static function getResourceType(): string
                 {
                     TypedOptional::triggerNotice(OptionalResource::class . ' does not check the type of resource.');

--- a/tests/OptionalObjectTest.php
+++ b/tests/OptionalObjectTest.php
@@ -29,6 +29,23 @@ final class OptionalObjectTest extends TestCase
         );
     }
 
+    public function testSameObjectIsStrictlyEqual(): void
+    {
+        $o = new stdClass();
+        $a = OptionalObject::of($o);
+        $b = OptionalObject::of($o);
+
+        self::assertTrue($a->equals($b, strict: true));
+    }
+
+    public function testEqualObjectsAreNotStrictlyEqual(): void
+    {
+        $a = OptionalObject::of(new stdClass());
+        $b = OptionalObject::of(new stdClass());
+
+        self::assertFalse($a->equals($b, strict: true));
+    }
+
     public function testEqualObjectsAreEqual(): void
     {
         $a = OptionalObject::of(new stdClass());

--- a/tests/Some/DataObject.php
+++ b/tests/Some/DataObject.php
@@ -6,6 +6,11 @@ namespace PetrKnap\Optional\Some;
 
 final class DataObject
 {
+    public function __construct(
+        public readonly string|null $value = null,
+    ) {
+    }
+
     /**
      * It works!
      *


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
