### PR TITLE
Added `else` argument to `ifPresent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ if ($optionalString->isPresent()) {
 OptionalResource::ofFalsable(tmpfile())->ifPresent(function ($tmpFile): void {
     fwrite($tmpFile, 'data');
     fclose($tmpFile);
-});
+}, else: fn () => print('tmpfile() failed'));
 ```
 
 ### Create and use your own typed optional

--- a/src/Optional.php
+++ b/src/Optional.php
@@ -153,10 +153,12 @@ abstract class Optional implements JavaSe8\Optional
         return $this->orElseThrow();
     }
 
-    public function ifPresent(callable $consumer): void
+    public function ifPresent(callable $consumer, callable|null $else = null): void
     {
         if ($this->value !== null) {
             $consumer($this->value);
+        } elseif ($else !== null) {
+            $else();
         }
     }
 

--- a/tests/OptionalTest.php
+++ b/tests/OptionalTest.php
@@ -225,22 +225,28 @@ final class OptionalTest extends TestCase
     }
 
     #[DataProvider('dataMethodIfPresentWorks')]
-    public function testMethodIfPresentWorks(Optional $optional, bool $expectedInvoke): void
+    public function testMethodIfPresentWorks(Optional $optional, string $expectedInvoked): void
     {
-        $invoked = false;
-        $optional->ifPresent(static function (string $value) use (&$invoked) {
-            self::assertSame(self::VALUE, $value);
-            $invoked = true;
-        });
+        $invoked = null;
+        $optional->ifPresent(
+            consumer: static function (string $value) use (&$invoked) {
+                self::assertSame(self::VALUE, $value);
+                $invoked = 'consumer';
+            },
+            else: static function (mixed ...$args) use (&$invoked) {
+                self::assertSame([], $args);
+                $invoked = 'else';
+            },
+        );
 
-        self::assertSame($expectedInvoke, $invoked);
+        self::assertSame($expectedInvoked, $invoked);
     }
 
     public static function dataMethodIfPresentWorks(): array
     {
         return self::makeDataSet([
-            [true],
-            [false],
+            ['consumer'],
+            ['else'],
         ]);
     }
 


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:
<!-- ⇅ remove it if it doesn't make sense ⇅ -->
<!-- ↓ here belongs the AI inputs (>>) and outputs (>) ↓ -->
>> Could you briefly summarize the following code for me?
>> ```php
>> OptionalResource::ofFalsable(tmpfile())->ifPresent(function ($tmpFile): void {
>>     fwrite($tmpFile, 'data');
>>     fclose($tmpFile);
>> }, else: fn () => print('tmpfile() failed'));
>> ```
>
> Certainly! This PHP code snippet demonstrates the use of an `OptionalResource` to handle a potentially false value returned by `tmpfile()`. Here's a breakdown:
> 1. `OptionalResource::ofFalsable(tmpfile())` wraps the result of `tmpfile()` in an `OptionalResource` object.
> 2. The `ifPresent` method takes two arguments: a function to execute if the `tmpfile()` was successful, and an alternative function if it failed.
> 3. If the `tmpfile()` is successful, it writes the string `'data'` to the temporary file and then closes it.
> 4. If the `tmpfile()` fails, it prints `'tmpfile() failed'`.
>
> So, in short, this code snippet ensures that appropriate actions are taken based on whether `tmpfile()` succeeds or fails. Let me know if you need further details!
