### PR TITLE
Implemented `ofSingle` factory method

### DIFF
--- a/src/Optional.php
+++ b/src/Optional.php
@@ -41,7 +41,7 @@ abstract class Optional implements JavaSe8\Optional
     }
 
     /**
-     * Many PHP functions return `false` on failure, this is a factory for them.
+     * In many cases a failure returns `false`, this method serves as a factory for them.
      *
      * @param T|false $value
      */
@@ -78,6 +78,23 @@ abstract class Optional implements JavaSe8\Optional
             };
         }
         return new static($value);
+    }
+
+    /**
+     * In many cases you will receive an `iterable` of single value, this method serves as a factory for them.
+     *
+     * @param iterable<T> $value
+     */
+    public static function ofSingle(iterable $value): static
+    {
+        $count = 0;
+        $item = null;
+        foreach ($value as $item) {
+            if (++$count > 1) {
+                throw new InvalidArgumentException('Count of value must not be greater than 1.');
+            }
+        }
+        return static::ofNullable($item);
     }
 
     /**

--- a/tests/OptionalTest.php
+++ b/tests/OptionalTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PetrKnap\Optional;
 
 use DomainException as SomeException;
+use InvalidArgumentException;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -60,6 +61,27 @@ final class OptionalTest extends TestCase
             [self::VALUE],
             [null],
         ]);
+    }
+
+    #[DataProvider('dataMethodOfSingleWorks')]
+    public function testMethodOfSingleWorks(Optional $expectedOptional, iterable $value): void
+    {
+        self::assertTrue(Optional::ofSingle($value)->equals($expectedOptional));
+    }
+
+    public static function dataMethodOfSingleWorks(): array
+    {
+        return self::makeDataSet([
+            [[self::VALUE]],
+            [[]],
+        ]);
+    }
+
+    public function testMethodOfSingleThrowsOnMultipleValues(): void
+    {
+        self::expectException(InvalidArgumentException::class);
+
+        Optional::ofSingle([self::VALUE, self::VALUE]);
     }
 
     #[DataProvider('dataMethodEqualsWorks')]


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.
- [x] I asked [the AI](https://copilot.microsoft.com/) to briefly summarize, use and improve the feature(s), and I'm okay with the output:

>> How to name `Optional`s factory method which will create `Optional<T>` from sole value of `Enumerable<T>` to match used pattern `of` something?
> 
> If you want the name to **match the pattern `ofX`**, then the cleanest choice is to express what kind of value the `Optional` is being created **from**.
>
> Since the method should create an `Optional<T>` **only when the `Enumerable<T>` contains exactly one element**, the most natural “of‑style” names are:
> 1. `ofSingle`
>    - Short, idiomatic, and directly expresses the intent.
>      - Meaning:
>        - If the sequence has exactly one element → return `Optional.Some(value)`
>        - Otherwise → return `Optional.None`
>    - This is the closest match to the naming pattern you described.
> 2. `ofOnly`
>    - A bit more functional/monadic in tone.
>    - This emphasizes the “only element” semantics.
> 3. `ofSole`
>    - If you want to mirror your own wording (“sole value”), this is a stylistically consistent option.
>    - It’s less common, but very clear.
>
> If your API already uses names like `of(value)`, `ofNullable(value)`, etc., then:
>
> 👉 `ofSingle` is the most natural extension of that pattern.
>
> It reads well, is easy to guess, and aligns with how Optional/Maybe factories are typically named.
>
>> There already are these factories: `of`, `ofNullable`, `ofFalsable`
>
> It’s clear your API uses a pattern where each factory describes **the condition under which an `Optional` becomes empty**.
>
> So the question becomes: What name best expresses “empty unless the enumerable contains exactly one element”?
>
> **🔍 What your existing names communicate**
>
> | Method        | Meaning                                                                        |
> |---------------|--------------------------------------------------------------------------------|
> | `of`          | Always wrap the value (never empty unless value is null and you forbid nulls). |
> | `ofNullable`  | Empty if the value is null.                                                    |
> | `ofFalsable`  | Empty if the value is “falsy” (false, 0, empty string, etc.).                  |
>
> Each name describes **the condition that makes the Optional empty**.
>
> So for an `IEnumerable<T>`, the condition is: **Empty unless the sequence contains exactly one element.**
>
> **⭐ Best matching name: `ofSingle`**
>
> It fits your naming pattern perfectly:
> - short
> - descriptive
> - consistent with `ofNullable` and `ofFalsable`
> - expresses the condition clearly
>
> ```java
> Optional<T> Optional.ofSingle(IEnumerable<T> source)
> ```
> Meaning:
> - If the sequence has exactly one element → return `Some(value)`
> - Otherwise → return `None`
>
>> Reflects it that it will be empty if the input set is empty?
>
> If you name the method `ofSingle`, `ofOnly`, or `ofSole`, then yes — these names naturally imply that the Optional will be empty when the input sequence does **not** contain exactly one element. That includes the case where the sequence is empty.
> 
>> Is there already similar factory of Java Optional?
>
> Java’s `Optional` **does not** include any factory method that takes a collection/stream/iterable and returns an `Optional` **only if it contains exactly one element**.
