### PR TITLE
Correct PhpDoc for `orElse` and `orElseGet`

### DIFF
--- a/src/JavaSe8/Optional.php
+++ b/src/JavaSe8/Optional.php
@@ -92,18 +92,18 @@ interface Optional
     /**
      * Return the value if present, otherwise return other.
      *
-     * @param T $other
+     * @param T|null $other
      *
-     * @return T
+     * @return ($other is T ? T : null)
      */
     public function orElse(mixed $other): mixed;
 
     /**
      * Return the value if present, otherwise invoke provided supplier and return the result of that invocation.
      *
-     * @param callable(): T $otherSupplier
+     * @param (callable(): T)|(callable(): (T|null)) $otherSupplier
      *
-     * @return T
+     * @return ($otherSupplier is (callable(): T) ? T : T|null)
      */
     public function orElseGet(callable $otherSupplier): mixed;
 

--- a/src/Optional.php
+++ b/src/Optional.php
@@ -241,13 +241,17 @@ abstract class Optional implements JavaSe8\Optional
     }
 
     /**
+     * @deprecated use {@see self::orElse()}
+     *
+     * @todo BC remove it
+     *
      * Inverse of {@see self::ofNullable()}
      *
      * @return T|null
      */
     public function toNullable(): mixed
     {
-        return $this->value;
+        return $this->orElse(null);
     }
 
     /**


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.

This works:
```java
Optional<Integer> a = Optional.of(1);
Integer b = a.orElse(null);
Integer c = a.orElseGet(() -> null);
```