### PR TITLE
Correct PhpDoc for `Optional::orElse`

### DIFF
--- a/src/JavaSe8/Optional.php
+++ b/src/JavaSe8/Optional.php
@@ -94,7 +94,7 @@ interface Optional
      *
      * @param T|null $other
      *
-     * @return ($other is T ? T : null)
+     * @return ($other is T ? T : T|null)
      */
     public function orElse(mixed $other): mixed;
 


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.

