### PR TITLE
`Optional::ofSingle` now correctly throws on `null`

### DIFF
--- a/src/Optional.php
+++ b/src/Optional.php
@@ -87,14 +87,14 @@ abstract class Optional implements JavaSe8\Optional
      */
     public static function ofSingle(iterable $value): static
     {
-        $count = 0;
-        $item = null;
-        foreach ($value as $item) {
-            if (++$count > 1) {
-                throw new InvalidArgumentException('Count of value must not be greater than 1.');
+        $option = null;
+        foreach ($value as $v) {
+            if ($option !== null) {
+                throw new InvalidArgumentException('Value is not single.');
             }
+            $option = static::of($v);
         }
-        return static::ofNullable($item);
+        return $option ?? static::empty();
     }
 
     /**

--- a/tests/OptionalTest.php
+++ b/tests/OptionalTest.php
@@ -77,6 +77,13 @@ final class OptionalTest extends TestCase
         ]);
     }
 
+    public function testMethodOfSingleThrowsOnNullValue(): void
+    {
+        self::expectException(InvalidArgumentException::class);
+
+        Optional::ofSingle([null]);
+    }
+
     public function testMethodOfSingleThrowsOnMultipleValues(): void
     {
         self::expectException(InvalidArgumentException::class);


### PR DESCRIPTION
- [x] This pull request does not contain any breaking change.

